### PR TITLE
Issue-22: Add translation to "As low as" string for Magento_ConfigurableProduct

### DIFF
--- a/github_contributions.csv
+++ b/github_contributions.csv
@@ -3,3 +3,4 @@
 "Sale Products","Produkte im Sale",module,Magento_Catalog
 "Latest Products","Neuste Produkte",module,Magento_Catalog
 "Random Products","Zufällige Produkte",module,Magento_Catalog
+"As low as","Ab",module,Magento_ConfigurableProduct


### PR DESCRIPTION
This PR will resolve [#Issue-22 ](https://github.com/mageplaza/magento-2-german-language-pack/issues/22)

Add translation to "As low as" string for Magento_ConfigurableProduct